### PR TITLE
Fix filters being cleared across all lists

### DIFF
--- a/src/modules/containers/reducers.js
+++ b/src/modules/containers/reducers.js
@@ -91,7 +91,7 @@ export const containers = (
     case CONTAINERS.CLEAR_FILTERS:
       return {
         ...state,
-        filters: {},
+        filters: set(state.filters, {}, {}),
         page: set(state.page, ['offset'], 0),
       };
 

--- a/src/modules/individuals/reducers.js
+++ b/src/modules/individuals/reducers.js
@@ -76,7 +76,7 @@ export const individuals = (
         case INDIVIDUALS.CLEAR_FILTERS:
             return {
                 ...state,
-                filters: {},
+                filters: set(state.filters, {}, {}),
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/src/modules/samples/reducers.js
+++ b/src/modules/samples/reducers.js
@@ -61,7 +61,7 @@ export const samples = (
         case SAMPLES.CLEAR_FILTERS:
             return {
                 ...state,
-                filters: {},
+                filters: set(state.filters, {}, {}),
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/src/modules/users/reducers.js
+++ b/src/modules/users/reducers.js
@@ -30,7 +30,7 @@ export const users = (
     case USERS.CLEAR_FILTERS:
       return {
         ...state,
-        filters: {},
+        filters: set(state.filters, {}, {}),
         page: set(state.page, ['offset'], 0),
       };
 


### PR DESCRIPTION
This fix ensures that when we click on ClearFilter button, only the filters from the appropriate list will be reset. 
Otherwise, the value of the filters from the other lists were also reset, but their actual list content was still being filtered.
