### PR TITLE
Fix renamed sample container indexes

### DIFF
--- a/src/components/filters/descriptions.js
+++ b/src/components/filters/descriptions.js
@@ -24,7 +24,7 @@ export const SAMPLE_FILTERS = {
     key: "container__name",
     label: "Container Name",
   },
-  container: {
+  container_barcode: {
     type: FILTER_TYPE.INPUT,
     key: "container__barcode",
     label: "Container Barcode",

--- a/src/components/samples/SamplesListContent.js
+++ b/src/components/samples/SamplesListContent.js
@@ -56,13 +56,13 @@ const getTableColumns = (containersByID, individualsByID) => [
     },
     {
       title: "Container Name",
-      dataIndexFilter: "container_name",
+      dataIndex: "container_name",
       sorter: true,
       render: (_, sample) => (sample.container && withContainer(containersByID, sample.container, container => container.name, "loading...")),
     },
     {
       title: "Container Barcode",
-      dataIndex: "container",
+      dataIndex: "container_barcode",
       sorter: true,
       render: container => (container &&
           <Link to={`/containers/${container}`}>


### PR DESCRIPTION
dataIndexFilter was a 'dead' attribute name remaining.

I renamed container to container_barcode, to clarify the distinction between container barcode and container name