### PR TITLE
Optimize withItem helpers

### DIFF
--- a/src/components/containers/ContainersListContent.js
+++ b/src/components/containers/ContainersListContent.js
@@ -9,7 +9,7 @@ import PaginatedTable from "../PaginatedTable";
 import AddButton from "../AddButton";
 import ExportButton from "../ExportButton";
 
-import {list, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/containers/actions";
+import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/containers/actions";
 import api, {withToken}  from "../../utils/api"
 import {actionsToButtonList} from "../../utils/templateActions";
 import {withContainer, withSample} from "../../utils/withItem";
@@ -98,7 +98,7 @@ const mapStateToProps = state => ({
   samplesByID: state.samples.itemsByID,
 });
 
-const actionCreators = {list, setFilter, setFilterOption, clearFilters, setSortBy};
+const actionCreators = {listTable, setFilter, setFilterOption, clearFilters, setSortBy};
 
 const ContainersListContent = ({
   token,
@@ -112,7 +112,7 @@ const ContainersListContent = ({
   isFetching,
   page,
   totalCount,
-  list,
+  listTable,
   setFilter,
   setFilterOption,
   clearFilters,
@@ -163,7 +163,7 @@ const ContainersListContent = ({
         page={page}
         filters={filters}
         sortBy={sortBy}
-        onLoad={list}
+        onLoad={listTable}
         onChangeSort={setSortBy}
       />
     </PageContent>

--- a/src/components/individuals/IndividualsListContent.js
+++ b/src/components/individuals/IndividualsListContent.js
@@ -12,7 +12,7 @@ import ExportButton from "../ExportButton";
 import AddButton from "../AddButton";
 
 import api, {withToken}  from "../../utils/api"
-import {list, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/individuals/actions";
+import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/individuals/actions";
 import {INDIVIDUAL_FILTERS} from "../filters/descriptions";
 import getFilterProps from "../filters/getFilterProps";
 import getNFilters from "../filters/getNFilters";
@@ -63,7 +63,7 @@ const mapStateToProps = state => ({
   sortBy: state.individuals.sortBy,
 });
 
-const mapDispatchToProps = {list, setFilter, setFilterOption, clearFilters, setSortBy};
+const mapDispatchToProps = {listTable, setFilter, setFilterOption, clearFilters, setSortBy};
 
 const IndividualsListContent = ({
   token,
@@ -74,7 +74,7 @@ const IndividualsListContent = ({
   totalCount,
   filters,
   sortBy,
-  list,
+  listTable,
   setFilter,
   setFilterOption,
   clearFilters,
@@ -126,7 +126,7 @@ const IndividualsListContent = ({
         page={page}
         filters={filters}
         sortBy={sortBy}
-        onLoad={list}
+        onLoad={listTable}
         onChangeSort={setSortBy}
       />
     </PageContent>

--- a/src/components/samples/SamplesListContent.js
+++ b/src/components/samples/SamplesListContent.js
@@ -15,7 +15,7 @@ import ExportButton from "../ExportButton";
 
 import api, {withToken}  from "../../utils/api"
 
-import {list, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/samples/actions";
+import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/samples/actions";
 import {actionsToButtonList} from "../../utils/templateActions";
 import {withContainer, withIndividual} from "../../utils/withItem";
 import {SAMPLE_FILTERS} from "../filters/descriptions";
@@ -120,7 +120,7 @@ const mapStateToProps = state => ({
   sortBy: state.samples.sortBy,
 });
 
-const actionCreators = {list, setFilter, setFilterOption, clearFilters, setSortBy};
+const actionCreators = {listTable, setFilter, setFilterOption, clearFilters, setSortBy};
 
 const SamplesListContent = ({
   token,
@@ -134,7 +134,7 @@ const SamplesListContent = ({
   containersByID,
   individualsByID,
   sortBy,
-  list,
+  listTable,
   setFilter,
   setFilterOption,
   clearFilters,
@@ -189,7 +189,7 @@ const SamplesListContent = ({
         page={page}
         filters={filters}
         sortBy={sortBy}
-        onLoad={list}
+        onLoad={listTable}
         onChangeSort={setSortBy}
       />
     </PageContent>

--- a/src/components/users/UsersListContent.js
+++ b/src/components/users/UsersListContent.js
@@ -9,7 +9,7 @@ import PageContent from "../PageContent";
 import PaginatedTable from "../PaginatedTable";
 
 
-import {list, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/users/actions";
+import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/users/actions";
 
 import {USER_FILTERS} from "../filters/descriptions";
 import getFilterProps from "../filters/getFilterProps";
@@ -64,7 +64,7 @@ const mapStateToProps = state => ({
   isFetching: state.users.isFetching,
 });
 
-const actionCreators = {list, setFilter, setFilterOption, clearFilters, setSortBy};
+const actionCreators = {listTable, setFilter, setFilterOption, clearFilters, setSortBy};
 
 const UsersListContent = ({
   users,
@@ -74,7 +74,7 @@ const UsersListContent = ({
   isFetching,
   page,
   totalCount,
-  list,
+  listTable,
   setFilter,
   setFilterOption,
   clearFilters,
@@ -117,7 +117,7 @@ const UsersListContent = ({
         page={page}
         filters={filters}
         sortBy={sortBy}
-        onLoad={list}
+        onLoad={listTable}
         onChangeSort={setSortBy}
       />
     </PageContent>

--- a/src/modules/containers/actions.js
+++ b/src/modules/containers/actions.js
@@ -13,6 +13,7 @@ export const SET_FILTER = "CONTAINERS.SET_FILTER";
 export const SET_FILTER_OPTION = "CONTAINERS.SET_FILTER_OPTION"
 export const CLEAR_FILTERS = "CONTAINERS.CLEAR_FILTERS";
 export const LIST = createNetworkActionTypes("CONTAINERS.LIST");
+export const LIST_TABLE = createNetworkActionTypes("CONTAINERS.LIST_TABLE");
 export const LIST_PARENTS = createNetworkActionTypes("CONTAINERS.LIST_PARENTS");
 export const LIST_CHILDREN = createNetworkActionTypes("CONTAINERS.LIST_CHILDREN");
 export const LIST_SAMPLES = createNetworkActionTypes("CONTAINERS.LIST_SAMPLES");
@@ -44,7 +45,15 @@ export const update = (id, container) => async (dispatch, getState) => {
         UPDATE, api.containers.update(container), { meta: { id, ignoreError: 'APIError' }}));
 };
 
-export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
+export const list = (options) => async (dispatch, getState) => {
+    const params = { limit: 100000, ...options }
+    return await dispatch(networkAction(LIST,
+        api.containers.list(params),
+        { meta: params }
+    ));
+};
+
+export const listTable = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
     const containers = getState().containers
     if (containers.isFetching && !abort)
         return
@@ -53,7 +62,7 @@ export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abor
     const ordering = serializeSortByParams(containers.sortBy)
     const options = { limit, offset, ordering, ...filters}
 
-    const res =  await dispatch(networkAction(LIST,
+    const res =  await dispatch(networkAction(LIST_TABLE,
         api.containers.list(options, abort),
         { meta: { ...options, ignoreError: 'AbortError' } }
     ));
@@ -148,6 +157,7 @@ export default {
     SET_FILTER_OPTION,
     CLEAR_FILTERS,
     LIST,
+    LIST_TABLE,
     LIST_PARENTS,
     LIST_CHILDREN,
     LIST_SAMPLES,
@@ -162,6 +172,7 @@ export default {
     setFilterOption,
     clearFilters,
     list,
+    listTable,
     listParents,
     listChildren,
     listSamples,
@@ -174,6 +185,6 @@ export default {
 function thenList(fn) {
     return (...args) => async dispatch => {
         dispatch(fn(...args))
-        dispatch(list(undefined, true))
+        dispatch(listTable(undefined, true))
     }
 }

--- a/src/modules/containers/reducers.js
+++ b/src/modules/containers/reducers.js
@@ -60,7 +60,7 @@ export const containers = (
       return merge(state, ['itemsByID', action.meta.id], { id: action.meta.id, isFetching: true });
     case CONTAINERS.GET.RECEIVE:
       return merge(state, ['itemsByID', action.meta.id],
-        { ...preprocessContainer(action.data), isFetching: false });
+        { ...preprocess(action.data), isFetching: false });
     case CONTAINERS.GET.ERROR:
       return merge(state, ['itemsByID', action.meta.id],
         { error: action.error, isFetching: false, didFail: true });
@@ -69,14 +69,14 @@ export const containers = (
       return { ...state, error: undefined, isFetching: true };
     case CONTAINERS.ADD.RECEIVE:
       return merge({ ...state, isFetching: false, }, ['itemsByID', action.data.id],
-        { ...preprocessContainer(action.data) });
+        { ...preprocess(action.data) });
     case CONTAINERS.ADD.ERROR:
       return { ...state, error: action.error, isFetching: false };
 
     case CONTAINERS.UPDATE.REQUEST:
       return merge(state, ['itemsByID', action.meta.id], { id: action.meta.id, isFetching: true });
     case CONTAINERS.UPDATE.RECEIVE:
-      return merge(state, ['itemsByID', action.meta.id], { ...preprocessContainer(action.data), isFetching: false, versions: undefined });
+      return merge(state, ['itemsByID', action.meta.id], { ...preprocess(action.data), isFetching: false, versions: undefined });
     case CONTAINERS.UPDATE.ERROR:
       return merge(state, ['itemsByID', action.meta.id],
         { error: action.error, isFetching: false });
@@ -109,28 +109,39 @@ export const containers = (
     case CONTAINERS.LIST.REQUEST:
       return { ...state, isFetching: true };
     case CONTAINERS.LIST.RECEIVE: {
-      const isTable = action.meta.isTable !== false
-      const totalCount = isTable ? action.data.count : state.totalCount;
-      const hasChanged = state.totalCount !== action.data.count && isTable;
+      const results = action.data.results.map(preprocess)
+      const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
+      return { ...state, itemsByID, isFetching: false, error: undefined };
+    }
+    case CONTAINERS.LIST.ERROR:
+      return { ...state, isFetching: false, error: action.error };
+
+    case CONTAINERS.LIST_TABLE.REQUEST:
+      return { ...state, isFetching: true };
+    case CONTAINERS.LIST_TABLE.RECEIVE: {
+      const totalCount = action.data.count;
+      const hasChanged = state.totalCount !== action.data.count;
       const currentItems = hasChanged ? [] : state.items;
-      const results = action.data.results.map(preprocessContainer)
+      const results = action.data.results.map(preprocess)
       const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
       const itemsID = results.map(r => r.id)
-      const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
+      const items = mergeArray(currentItems, action.meta.offset, itemsID)
       return {
         ...state,
         itemsByID,
         items,
         totalCount,
-        page: isTable ? action.meta : state.page,
+        page: action.meta,
         isFetching: false,
+        error: undefined,
       };
     }
-    case CONTAINERS.LIST.ERROR:
+    case CONTAINERS.LIST_TABLE.ERROR:
       return { ...state, isFetching: false, error: action.error };
 
     /* Normalize samples[].container */
-    case SAMPLES.LIST.RECEIVE: {
+    case SAMPLES.LIST.RECEIVE:
+    case SAMPLES.LIST_TABLE.RECEIVE: {
       const samples = action.data.results;
       const containers = samples.map(s => s.container).filter(Boolean)
       const itemsByID = merge(state.itemsByID, [], indexByID(containers, "id"));
@@ -140,7 +151,7 @@ export const containers = (
     case CONTAINERS.LIST_PARENTS.REQUEST:
       return merge(state, ['itemsByID', action.meta.id], { id: action.meta.id, isFetching: true });
     case CONTAINERS.LIST_PARENTS.RECEIVE: {
-      const parents = action.data.map(preprocessContainer);
+      const parents = action.data.map(preprocess);
       const parentsID = parents.map(p => p.id);
       const itemsByID = merge(state.itemsByID, [], indexByID(parents))
       return merge(state, ['itemsByID'],
@@ -162,7 +173,7 @@ export const containers = (
     }
     case CONTAINERS.LIST_CHILDREN.RECEIVE: {
       const container = state.itemsByID[action.meta.id];
-      const items = action.data.map(preprocessContainer);
+      const items = action.data.map(preprocess);
       const itemsByID = merge(state.itemsByID, [], indexByID(items))
       itemsByID[action.meta.id] = set(container, ['isFetching'], false);
       return merge(state, ['itemsByID'], itemsByID);
@@ -185,7 +196,7 @@ export const containers = (
   }
 };
 
-function preprocessContainer(container) {
+function preprocess(container) {
   container.isFetching = false
   container.isLoaded = true
   return container;

--- a/src/modules/containers/reducers.js
+++ b/src/modules/containers/reducers.js
@@ -109,18 +109,20 @@ export const containers = (
     case CONTAINERS.LIST.REQUEST:
       return { ...state, isFetching: true };
     case CONTAINERS.LIST.RECEIVE: {
-      const hasChanged = state.totalCount !== action.data.count;
+      const isTable = action.meta.isTable !== false
+      const totalCount = isTable ? action.data.count : state.totalCount;
+      const hasChanged = state.totalCount !== action.data.count && isTable;
       const currentItems = hasChanged ? [] : state.items;
       const results = action.data.results.map(preprocessContainer)
       const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
       const itemsID = results.map(r => r.id)
-      const items = mergeArray(currentItems, action.meta.offset, itemsID)
+      const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
       return {
         ...state,
         itemsByID,
         items,
-        totalCount: action.data.count,
-        page: action.meta,
+        totalCount,
+        page: isTable ? action.meta : state.page,
         isFetching: false,
       };
     }

--- a/src/modules/individuals/actions.js
+++ b/src/modules/individuals/actions.js
@@ -9,6 +9,7 @@ export const GET = createNetworkActionTypes("INDIVIDUALS.GET");
 export const ADD = createNetworkActionTypes("INDIVIDUALS.ADD");
 export const UPDATE = createNetworkActionTypes("INDIVIDUALS.UPDATE");
 export const LIST = createNetworkActionTypes("INDIVIDUALS.LIST");
+export const LIST_TABLE = createNetworkActionTypes("INDIVIDUALS.LIST_TABLE");
 export const SET_SORT_BY = "INDIVIDUALS.SET_SORT_BY"
 export const SET_FILTER = "INDIVIDUALS.SET_FILTER";
 export const SET_FILTER_OPTION = "INDIVIDUALS.SET_FILTER_OPTION"
@@ -38,7 +39,15 @@ export const update = (id, individual) => async (dispatch, getState) => {
         UPDATE, api.individuals.update(individual), { meta: { id, ignoreError: 'APIError' }}));
 };
 
-export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
+export const list = (options) => async (dispatch, getState) => {
+    const params = { limit: 100000, ...options }
+    return await dispatch(networkAction(LIST,
+        api.individuals.list(params),
+        { meta: params }
+    ));
+};
+
+export const listTable = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
     const {individuals} = getState();
     if (individuals.isFetching && !abort)
         return
@@ -47,7 +56,7 @@ export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abor
     const ordering = serializeSortByParams(individuals.sortBy)
     const options = { limit, offset, ordering, ...filters }
 
-    return await dispatch(networkAction(LIST,
+    return await dispatch(networkAction(LIST_TABLE,
         api.individuals.list(options, abort),
         { meta: { ...options, ignoreError: 'AbortError' } }
     ));
@@ -85,6 +94,7 @@ export default {
     ADD,
     UPDATE,
     LIST,
+    LIST_TABLE,
     SET_SORT_BY,
     SET_FILTER,
     SET_FILTER_OPTION,
@@ -93,6 +103,7 @@ export default {
     add,
     update,
     list,
+    listTable,
     setSortBy,
     setFilter,
     setFilterOption,
@@ -103,6 +114,6 @@ export default {
 function thenList(fn) {
     return (...args) => async dispatch => {
         dispatch(fn(...args))
-        dispatch(list(undefined, true))
+        dispatch(listTable(undefined, true))
     }
 }

--- a/src/modules/individuals/reducers.js
+++ b/src/modules/individuals/reducers.js
@@ -44,17 +44,20 @@ export const individuals = (
         case INDIVIDUALS.LIST.REQUEST:
             return { ...state, isFetching: true };
         case INDIVIDUALS.LIST.RECEIVE: {
-            const hasChanged = state.totalCount !== action.data.count;
+            const isTable = action.meta.isTable !== false
+            const totalCount = isTable ? action.data.count : state.totalCount;
+            const hasChanged = state.totalCount !== action.data.count && isTable;
             const currentItems = hasChanged ? [] : state.items;
-            const itemsByID = merge(state.itemsByID, [], indexByID(action.data.results, "id"));
-            const itemsID = action.data.results.map(r => r.id)
-            const items = mergeArray(currentItems, action.meta.offset, itemsID)
+            const results = action.data.results.map(preprocessIndividual)
+            const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
+            const itemsID = results.map(r => r.id)
+            const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
             return {
                 ...state,
                 itemsByID,
                 items,
-                totalCount: action.data.count,
-                page: action.meta,
+                totalCount,
+                page: isTable ? action.meta : state.page,
                 isFetching: false,
             };
         }
@@ -94,3 +97,8 @@ export const individuals = (
             return state;
     }
 };
+
+function preprocessIndividual(individual) {
+    individual.isFetching = false
+    return individual
+}

--- a/src/modules/samples/actions.js
+++ b/src/modules/samples/actions.js
@@ -9,6 +9,7 @@ export const GET                   = createNetworkActionTypes("SAMPLES.GET");
 export const ADD                   = createNetworkActionTypes("SAMPLES.ADD");
 export const UPDATE                = createNetworkActionTypes("SAMPLES.UPDATE");
 export const LIST                  = createNetworkActionTypes("SAMPLES.LIST");
+export const LIST_TABLE            = createNetworkActionTypes("SAMPLES.LIST_TABLE");
 export const SET_SORT_BY           = "SAMPLES.SET_SORT_BY";
 export const SET_FILTER            = "SAMPLES.SET_FILTER";
 export const SET_FILTER_OPTION    = "SAMPLES.SET_FILTER_OPTION"
@@ -41,7 +42,15 @@ export const update = (id, sample) => async (dispatch, getState) => {
         UPDATE, api.samples.update(sample), { meta: { id, ignoreError: 'APIError' }}));
 };
 
-export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
+export const list = (options) => async (dispatch, getState) => {
+    const params = { limit: 100000, ...options }
+    return await dispatch(networkAction(LIST,
+        api.samples.list(params),
+        { meta: params }
+    ));
+};
+
+export const listTable = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
     const samples = getState().samples
     if (samples.isFetching && !abort)
         return
@@ -50,7 +59,7 @@ export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abor
     const ordering = serializeSortByParams(samples.sortBy)
     const options = { limit, offset, ordering, ...filters}
 
-    return await dispatch(networkAction(LIST,
+    return await dispatch(networkAction(LIST_TABLE,
         api.samples.list(options, abort),
         { meta: { ...options, ignoreError: 'AbortError' } }
     ));
@@ -110,6 +119,7 @@ export default {
     SET_FILTER_OPTION,
     CLEAR_FILTERS,
     LIST,
+    LIST_TABLE,
     SUMMARY,
     LIST_VERSIONS,
     LIST_TEMPLATE_ACTIONS,
@@ -121,6 +131,7 @@ export default {
     setFilterOption,
     clearFilters,
     list,
+    listTable,
     listVersions,
     listTemplateActions,
     summary,
@@ -130,6 +141,6 @@ export default {
 function thenList(fn) {
     return (...args) => async dispatch => {
         dispatch(fn(...args))
-        dispatch(list(undefined, true))
+        dispatch(listTable(undefined, true))
     }
 }

--- a/src/modules/samples/reducers.js
+++ b/src/modules/samples/reducers.js
@@ -79,22 +79,25 @@ export const samples = (
         case SAMPLES.LIST.REQUEST:
             return { ...state, isFetching: true, };
         case SAMPLES.LIST.RECEIVE: {
-            const hasChanged = state.totalCount !== action.data.count;
+            const isTable = action.meta.isTable !== false
+            const totalCount = isTable ? action.data.count : state.totalCount;
+            const hasChanged = state.totalCount !== action.data.count && isTable;
             const currentItems = hasChanged ? [] : state.items;
             /* samples[].container stored in ../containers/reducers.js */
+            const results = action.data.results.map(preprocessSample)
             const newItemsByID = map(
                 s => ({ ...s, container: s.container }),
-                indexByID(action.data.results)
+                indexByID(results)
             );
             const itemsByID = merge(state.itemsByID, [], newItemsByID);
             const itemsID = action.data.results.map(r => r.id)
-            const items = mergeArray(currentItems, action.meta.offset, itemsID)
+            const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
             return {
                 ...state,
                 itemsByID,
                 items,
-                totalCount: action.data.count,
-                page: action.meta,
+                totalCount,
+                page: isTable ? action.meta : state.page,
                 isFetching: false,
             };
         }

--- a/src/modules/samples/reducers.js
+++ b/src/modules/samples/reducers.js
@@ -39,7 +39,7 @@ export const samples = (
             return { ...state, error: undefined, isFetching: true };
         case SAMPLES.ADD.RECEIVE:
             return merge({ ...state, isFetching: false, }, ['itemsByID', action.data.id],
-                preprocessSample(action.data));
+                preprocess(action.data));
         case SAMPLES.ADD.ERROR:
             return { ...state, error: action.error, isFetching: false };
 
@@ -79,29 +79,40 @@ export const samples = (
         case SAMPLES.LIST.REQUEST:
             return { ...state, isFetching: true, };
         case SAMPLES.LIST.RECEIVE: {
-            const isTable = action.meta.isTable !== false
-            const totalCount = isTable ? action.data.count : state.totalCount;
-            const hasChanged = state.totalCount !== action.data.count && isTable;
+            /* samples[].container stored in ../containers/reducers.js */
+            const results = action.data.results.map(preprocess)
+            const itemsByID = merge(state.itemsByID, [], indexByID(results));
+            return { ...state, itemsByID, isFetching: false, error: undefined };
+        }
+        case SAMPLES.LIST.ERROR:
+            return { ...state, isFetching: false, error: action.error, };
+
+        case SAMPLES.LIST_TABLE.REQUEST:
+            return { ...state, isFetching: true, };
+        case SAMPLES.LIST_TABLE.RECEIVE: {
+            const totalCount = action.data.count;
+            const hasChanged = state.totalCount !== action.data.count;
             const currentItems = hasChanged ? [] : state.items;
             /* samples[].container stored in ../containers/reducers.js */
-            const results = action.data.results.map(preprocessSample)
+            const results = action.data.results.map(preprocess)
             const newItemsByID = map(
                 s => ({ ...s, container: s.container }),
                 indexByID(results)
             );
             const itemsByID = merge(state.itemsByID, [], newItemsByID);
             const itemsID = action.data.results.map(r => r.id)
-            const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
+            const items = mergeArray(currentItems, action.meta.offset, itemsID)
             return {
                 ...state,
                 itemsByID,
                 items,
                 totalCount,
-                page: isTable ? action.meta : state.page,
+                page: action.meta,
                 isFetching: false,
+                error: undefined,
             };
         }
-        case SAMPLES.LIST.ERROR:
+        case SAMPLES.LIST_TABLE.ERROR:
             return { ...state, isFetching: false, error: action.error, };
 
         case SAMPLES.LIST_VERSIONS.REQUEST:
@@ -127,7 +138,7 @@ export const samples = (
             return merge(state, ['itemsByID'], itemsByID);
         }
         case CONTAINERS.LIST_SAMPLES.RECEIVE: {
-            return merge(state, ['itemsByID'], indexByID(action.data.map(preprocessSample)));
+            return merge(state, ['itemsByID'], indexByID(action.data.map(preprocess)));
         }
         case CONTAINERS.LIST_SAMPLES.ERROR: {
             const itemsByID =
@@ -141,7 +152,7 @@ export const samples = (
     }
 };
 
-function preprocessSample(sample) {
+function preprocess(sample) {
     sample.isFetching = false;
     sample.isLoaded = true;
     return sample

--- a/src/modules/shared/actions.js
+++ b/src/modules/shared/actions.js
@@ -12,12 +12,12 @@ export const fetchInitialData = () => async (dispatch, getState) => {
     // Higher priority
     await Promise.all([
         Containers.listKinds,
-        Containers.list,
+        Containers.listTable,
         Containers.summary,
-        Individuals.list,
-        Samples.list,
+        Individuals.listTable,
+        Samples.listTable,
         Samples.summary,
-        Users.list,
+        Users.listTable,
     ].map(a => dispatch(a())))
 
     // Lower priority

--- a/src/modules/users/actions.js
+++ b/src/modules/users/actions.js
@@ -5,14 +5,23 @@ import serializeSortByParams from "../../utils/serializeSortByParams";
 import {USER_FILTERS} from "../../components/filters/descriptions";
 import {DEFAULT_PAGINATION_LIMIT} from "../../config";
 
-export const LIST          = createNetworkActionTypes("USERS.LIST");
+export const LIST = createNetworkActionTypes("USERS.LIST");
+export const LIST_TABLE = createNetworkActionTypes("USERS.LIST_TABLE");
 export const LIST_VERSIONS = createNetworkActionTypes("USERS.LIST_VERSIONS");
 export const SET_SORT_BY = "USERS.SET_SORT_BY";
 export const SET_FILTER = "USERS.SET_FILTER";
 export const SET_FILTER_OPTION = "USERS.SET_FILTER_OPTION"
 export const CLEAR_FILTERS = "USERS.CLEAR_FILTERS";
 
-export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
+export const list = (options) => async (dispatch, getState) => {
+    const params = { limit: 100000, ...options }
+    return await dispatch(networkAction(LIST,
+        api.users.list(params),
+        { meta: params }
+    ));
+};
+
+export const listTable = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abort) => async (dispatch, getState) => {
     const users = getState().users
     if (users.isFetching && !abort)
         return
@@ -21,7 +30,7 @@ export const list = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {}, abor
     const ordering = serializeSortByParams(users.sortBy)
     const options = { limit, offset, ordering, ...filters}
 
-    const res =  await dispatch(networkAction(LIST,
+    const res =  await dispatch(networkAction(LIST_TABLE,
         api.users.list(options, abort),
         { meta: { ...options, ignoreError: 'AbortError' } }
     ));
@@ -65,12 +74,14 @@ export const clearFilters = thenList(() => {
 
 export default {
     LIST,
+    LIST_TABLE,
     LIST_VERSIONS,
     SET_SORT_BY,
     SET_FILTER,
     SET_FILTER_OPTION,
     CLEAR_FILTERS,
     list,
+    listTable,
     listVersions,
     setSortBy,
     setFilter,
@@ -82,6 +93,6 @@ export default {
 function thenList(fn) {
     return (...args) => async dispatch => {
         dispatch(fn(...args))
-        dispatch(list(undefined, true))
+        dispatch(listTable(undefined, true))
     }
 }

--- a/src/modules/users/reducers.js
+++ b/src/modules/users/reducers.js
@@ -43,18 +43,20 @@ export const users = (
     case USERS.LIST.REQUEST:
       return { ...state, isFetching: true };
     case USERS.LIST.RECEIVE: {
-      const hasChanged = state.totalCount !== action.data.count;
+      const isTable = action.meta.isTable !== false
+      const totalCount = isTable ? action.data.count : state.totalCount;
+      const hasChanged = state.totalCount !== action.data.count && isTable;
       const currentItems = hasChanged ? [] : state.items;
       const results = action.data.results.map(preprocessUser)
       const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
       const itemsID = results.map(r => r.id)
-      const items = mergeArray(currentItems, action.meta.offset, itemsID)
+      const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
       return {
         ...state,
         itemsByID,
         items,
-        totalCount: action.data.count,
-        page: action.meta,
+        totalCount,
+        page: isTable ? action.meta : state.page,
         isFetching: false,
       };
     }

--- a/src/modules/users/reducers.js
+++ b/src/modules/users/reducers.js
@@ -43,24 +43,39 @@ export const users = (
     case USERS.LIST.REQUEST:
       return { ...state, isFetching: true };
     case USERS.LIST.RECEIVE: {
-      const isTable = action.meta.isTable !== false
-      const totalCount = isTable ? action.data.count : state.totalCount;
-      const hasChanged = state.totalCount !== action.data.count && isTable;
+      const results = action.data.results.map(preprocess)
+      const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
+      return {
+        ...state,
+        itemsByID,
+        isFetching: false,
+        error: undefined,
+      };
+    }
+    case USERS.LIST.ERROR:
+      return { ...state, isFetching: false, error: action.error };
+
+    case USERS.LIST_TABLE.REQUEST:
+      return { ...state, isFetching: true };
+    case USERS.LIST_TABLE.RECEIVE: {
+      const totalCount = action.data.count;
+      const hasChanged = state.totalCount !== action.data.count;
       const currentItems = hasChanged ? [] : state.items;
-      const results = action.data.results.map(preprocessUser)
+      const results = action.data.results.map(preprocess)
       const itemsByID = merge(state.itemsByID, [], indexByID(results, "id"));
       const itemsID = results.map(r => r.id)
-      const items = isTable ? mergeArray(currentItems, action.meta.offset, itemsID) : currentItems
+      const items = mergeArray(currentItems, action.meta.offset, itemsID)
       return {
         ...state,
         itemsByID,
         items,
         totalCount,
-        page: isTable ? action.meta : state.page,
+        page: action.meta,
         isFetching: false,
+        error: undefined,
       };
     }
-    case USERS.LIST.ERROR:
+    case USERS.LIST_TABLE.ERROR:
       return { ...state, isFetching: false, error: action.error };
 
     case USERS.LIST_VERSIONS.REQUEST:
@@ -82,6 +97,6 @@ export const users = (
   }
 };
 
-function preprocessUser(user) {
+function preprocess(user) {
   return user
 }

--- a/src/utils/wait.js
+++ b/src/utils/wait.js
@@ -1,0 +1,9 @@
+/*
+ * wait.js
+ */
+
+export default function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/src/utils/withItem.js
+++ b/src/utils/withItem.js
@@ -6,7 +6,6 @@ import api from ".//api"
 import wait from "./wait"
 
 const THROTTLE_DELAY = 20
-const PAGE_LIMIT = 1000000 // We don't want to handle pagination here
 
 let store = undefined
 
@@ -39,13 +38,9 @@ function createWithItem(type, apiType) {
     delayedAction =
       wait(THROTTLE_DELAY).then(async () => {
         const params = {
-          limit: PAGE_LIMIT,
           id__in: Array.from(ids).join(',')
         }
-        const listAction = store.dispatch(networkAction(type.LIST,
-            apiType.list(params),
-            { meta: { ...params, isTable: false } }
-        ))
+        const listAction = store.dispatch(type.list(params))
         ids = new Set()
         await listAction
         delayedAction = undefined

--- a/src/utils/withItem.js
+++ b/src/utils/withItem.js
@@ -1,82 +1,78 @@
 import Container from "../modules/containers/actions.js"
 import Sample from "../modules/samples/actions.js"
 import Individual from "../modules/individuals/actions.js"
+import {networkAction} from "./actions";
+import api from ".//api"
+import wait from "./wait"
 
 let store = undefined
 
 /** Initialized in src/index.js */
 export const setStore = value => { store = value }
 
-/**
- * 
- * @param {string} id 
- * @param {Function} fn 
- * @param {any} [defaultValue = null] 
- */
-export const withContainer = (containersByID, id, fn, defaultValue = null) => {
-  if (!id)
-    return defaultValue
+function createWithItem(type, apiType) {
+  let ids = new Set()
+  let delayedAction
 
-  const container = containersByID[id]
-
-  if (!container) {
-    store.dispatch(Container.get(id))      
-    return defaultValue
+  const requestItem = (id) => {
+    if (ids.has(id))
+      return
+    store.dispatch({ type: type.GET.REQUEST, meta: { id } })
+    ids.add(id)
+    if (delayedAction)
+      return
+    fetchList()
   }
 
-  if (container.isFetching)
-    return defaultValue
+  const fetchList = () => {
+    delayedAction =
+      wait(20).then(async () => {
+        const params = {
+          limit: 25,
+          id__in: Array.from(ids).join(',')
+        }
+        const listAction = store.dispatch(networkAction(type.LIST,
+            apiType.list(params),
+            { meta: { ...params, isTable: false } }
+        ))
+        ids = new Set()
+        await listAction
+        delayedAction = undefined
+        // Some items were added while we were fetching the ids
+        if (ids.size > 0)
+          fetchList()
+      })
+    console.log('fetchList', delayedAction)
+  }
 
-  return fn(container)
+  /**
+   * @param {string} id
+   * @param {Function} fn
+   * @param {any} [defaultValue = null]
+   */
+  const withItem = (containersByID, id, fn, defaultValue = null) => {
+    if (!id)
+      return defaultValue
+
+    const container = containersByID[id]
+
+    if (!container) {
+      requestItem(id)
+      return defaultValue
+    }
+
+    if (container.isFetching)
+      return defaultValue
+
+    return fn(container)
+  }
+
+  return withItem
 }
 
-/**
- * 
- * @param {string} id 
- * @param {Function} fn 
- * @param {any} [defaultValue = null] 
- */
-export const withSample = (samplesByID, id, fn, defaultValue = null) => {
-  if (!id)
-    return defaultValue
-
-  const sample = samplesByID[id]
-
-  if (!sample) {
-    store.dispatch(Sample.get(id))      
-    return defaultValue
-  }
-
-  if (sample.isFetching)
-    return defaultValue
-
-  return fn(sample)
-}
-
-/**
- * 
- * @param {string} id 
- * @param {Function} fn 
- * @param {any} [defaultValue = null] 
- */
-export const withIndividual = (individualsByID, id, fn, defaultValue = null) => {
-  if (!id) {
-    return defaultValue
-  }
-  
-  const individual = individualsByID[id]
-
-  if (!individual) {
-    store.dispatch(Individual.get(id))      
-    return defaultValue
-  }
-
-  if (individual.isFetching)
-    return defaultValue
-
-  return fn(individual)
-}
-
+export const withContainer = createWithItem(Container, api.containers)
+export const withSample = createWithItem(Sample, api.samples)
+export const withIndividual = createWithItem(Individual, api.individuals)
 export default {
   withContainer,
   withSample,


### PR DESCRIPTION
The `withX()` helpers currently fetch items one by one, which is very unefficient in terms of requests. The server being in python, this is even more needed to reduce the load.

One issue that is arising however is how reducers are becoming quite complicated because we don't differentiate between the actions list-items-data and list-ordered-items-for-paginated-table.