### PR TITLE
Cleanup: remove style imports

### DIFF
--- a/src/components/ActionContent.js
+++ b/src/components/ActionContent.js
@@ -2,10 +2,7 @@ import React, {useEffect} from "react";
 import {connect} from "react-redux";
 import {useHistory, useRouteMatch} from "react-router-dom";
 import PropTypes from "prop-types";
-
 import {Button} from "antd";
-import "antd/es/button/style/css";
-
 import {DownloadOutlined} from "@ant-design/icons";
 
 import {fetchAuthorizedData} from "../modules/shared/actions";

--- a/src/components/AddButton.js
+++ b/src/components/AddButton.js
@@ -1,9 +1,6 @@
 import React from "react";
 import {useHistory} from "react-router-dom";
-
 import {Button} from "antd";
-import "antd/es/button/style/css";
-
 import {PlusOutlined} from "@ant-design/icons";
 
 const AddButton = ({url, ...rest}) => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,12 +2,7 @@ import React, {useEffect} from "react";
 import {hot} from "react-hot-loader/root";
 import {connect} from "react-redux";
 import {Redirect, Route, Switch, withRouter} from "react-router-dom";
-
 import {Layout, Menu, Typography} from "antd";
-import "antd/es/layout/style/css";
-import "antd/es/menu/style/css";
-import "antd/es/typography/style/css";
-
 import {
   AuditOutlined,
   DashboardOutlined,

--- a/src/components/AppPageHeader.js
+++ b/src/components/AppPageHeader.js
@@ -1,7 +1,5 @@
 import React from "react";
-
 import {PageHeader} from "antd";
-import "antd/es/page-header/style/css";
 
 const style = {
   backgroundColor: "rgba(0, 0, 0, 0.03)",

--- a/src/components/DashboardPage.js
+++ b/src/components/DashboardPage.js
@@ -1,14 +1,7 @@
 import React, {useEffect} from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
-
 import {Button, Card, Col, Row, Statistic} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/card/style/css";
-import "antd/es/col/style/css";
-import "antd/es/row/style/css";
-import "antd/es/statistic/style/css";
-
 
 import CONTAINERS from "../modules/containers/actions";
 import SAMPLES from "../modules/samples/actions";

--- a/src/components/EditButton.js
+++ b/src/components/EditButton.js
@@ -1,9 +1,6 @@
 import React from "react";
 import {useHistory} from "react-router-dom";
-
 import {Button} from "antd";
-import "antd/es/button/style/css";
-
 import {EditOutlined} from "@ant-design/icons";
 
 const EditButton = ({url}) => {

--- a/src/components/ErrorMessage.js
+++ b/src/components/ErrorMessage.js
@@ -1,7 +1,5 @@
 import React from "react";
-
 import {Alert} from "antd";
-import "antd/es/alert/style/css";
 
 const ErrorMessage = ({title, description, error}) =>
   <Alert

--- a/src/components/ExportButton.js
+++ b/src/components/ExportButton.js
@@ -1,9 +1,6 @@
 import React, {useState} from "react";
 import {downloadFromText} from "../utils/download";
-
 import {Button, notification} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/notification/style/css";
 
 import { DownloadOutlined } from "@ant-design/icons";
 

--- a/src/components/JumpBar.js
+++ b/src/components/JumpBar.js
@@ -2,7 +2,6 @@ import React, {useState} from "react";
 import {bindActionCreators} from "redux";
 import {connect} from "react-redux";
 import {useHistory} from "react-router-dom";
-
 import {
   UserOutlined,
   TableOutlined,
@@ -10,9 +9,6 @@ import {
   ExperimentOutlined
 } from "@ant-design/icons";
 import {Select, Tag, Typography} from "antd";
-import "antd/es/select/style/css";
-import "antd/es/tag/style/css";
-import "antd/es/typography/style/css";
 
 import {clear, search} from "../modules/query/actions";
 

--- a/src/components/PageContent.js
+++ b/src/components/PageContent.js
@@ -1,7 +1,5 @@
 import React from "react";
-
 import {Spin} from "antd";
-import "antd/es/spin/style/css";
 
 const defaultStyle = {
   flex: "1",

--- a/src/components/PaginatedTable.js
+++ b/src/components/PaginatedTable.js
@@ -1,9 +1,6 @@
 import React, {useState, useRef} from "react";
 import prop from "prop-types";
-
 import {Pagination, Table} from "antd";
-import "antd/es/pagination/style/css";
-import "antd/es/table/style/css";
 
 
 const pageSize = 10;

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -1,12 +1,7 @@
 import React, {useEffect} from "react";
 import {connect} from "react-redux";
 import {useHistory} from "react-router-dom";
-
 import {Card, Button, Form, Input} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/card/style/css";
-import "antd/es/form/style/css";
-import "antd/es/input/style/css";
 import {LoginOutlined} from "@ant-design/icons";
 
 import {performAuth} from "../modules/auth/actions";

--- a/src/components/TemplateFlow.js
+++ b/src/components/TemplateFlow.js
@@ -1,14 +1,6 @@
 import React, {useState} from "react";
 import PropTypes from "prop-types";
-
 import {Alert, Button, Form, Steps, Upload, Row, Col} from "antd";
-import "antd/es/alert/style/css";
-import "antd/es/button/style/css";
-import "antd/es/form/style/css";
-import "antd/es/steps/style/css";
-import "antd/es/upload/style/css";
-import "antd/es/row/style/css";
-import "antd/es/col/style/css";
 
 import {
   ArrowRightOutlined,

--- a/src/components/containers/ContainerEditContent.js
+++ b/src/components/containers/ContainerEditContent.js
@@ -1,15 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {connect} from "react-redux";
 import {useHistory, useParams} from "react-router-dom";
-
-import {Alert, AutoComplete, Button, Form, Input, Select, Typography} from "antd";
-import "antd/es/alert/style/css";
-import "antd/es/auto-complete/style/css";
-import "antd/es/button/style/css";
-import "antd/es/form/style/css";
-import "antd/es/input/style/css";
-import "antd/es/select/style/css";
-import "antd/es/typography/style/css";
+import {Alert, Button, Form, Input, Select} from "antd";
 const {Option} = Select;
 const {Item} = Form;
 const {TextArea} = Input;

--- a/src/components/containers/ContainerHierarchy.js
+++ b/src/components/containers/ContainerHierarchy.js
@@ -2,10 +2,7 @@ import React, { useState, useEffect } from "react";
 import {useHistory} from "react-router-dom";
 import {connect} from "react-redux";
 import {set} from "object-path-immutable";
-
 import {Tree, Typography} from "antd";
-import "antd/es/tree/style/css";
-import "antd/es/typography/style/css";
 
 import {
   LoadingOutlined,

--- a/src/components/containers/ContainersDetailContent.js
+++ b/src/components/containers/ContainersDetailContent.js
@@ -1,10 +1,7 @@
 import React from "react";
 import {connect} from "react-redux";
 import {useHistory, useParams, Link} from "react-router-dom";
-
 import {Space, Descriptions} from "antd";
-import "antd/es/descriptions/style/css";
-import "antd/es/space/style/css";
 
 import AppPageHeader from "../AppPageHeader";
 import ContainerHierarchy from "./ContainerHierarchy";

--- a/src/components/filters/FilterInput.js
+++ b/src/components/filters/FilterInput.js
@@ -1,7 +1,5 @@
 import React from "react";
 import {Input} from "antd";
-import "antd/es/input/style/css";
-import "antd/es/input-number/style/css";
 import FilterLabel from "./FilterLabel"
 import * as style from "./style"
 

--- a/src/components/filters/FilterRange.js
+++ b/src/components/filters/FilterRange.js
@@ -1,7 +1,5 @@
 import React from "react";
 import {Input, InputNumber} from "antd";
-import "antd/es/input/style/css";
-import "antd/es/input-number/style/css";
 import FilterLabel from "./FilterLabel"
 import * as style from "./style"
 

--- a/src/components/filters/FilterSelect.js
+++ b/src/components/filters/FilterSelect.js
@@ -1,7 +1,5 @@
 import React from "react";
 import {Radio, Select} from "antd";
-import "antd/es/radio/style/css";
-import "antd/es/select/style/css";
 
 import FilterLabel from "./FilterLabel"
 import * as style from "./style"

--- a/src/components/filters/FiltersWarning.js
+++ b/src/components/filters/FiltersWarning.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {Tooltip, Typography} from "antd";
-import "antd/es/typography/style/css";
 const {Text} = Typography
 import {QuestionCircleOutlined} from "@ant-design/icons";
 

--- a/src/components/filters/getFilterProps.js
+++ b/src/components/filters/getFilterProps.js
@@ -1,12 +1,5 @@
 import React, {useRef} from "react";
 import {Button, Input, InputNumber, Radio, Select, Switch, Space, Tooltip} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/input/style/css";
-import "antd/es/radio/style/css";
-import "antd/es/select/style/css";
-import "antd/es/switch/style/css";
-import "antd/es/space/style/css";
-import "antd/es/tooltip/style/css";
 import {SearchOutlined} from "@ant-design/icons";
 
 import {FILTER_TYPE} from "../../constants";

--- a/src/components/individuals/IndividualEditContent.js
+++ b/src/components/individuals/IndividualEditContent.js
@@ -1,14 +1,7 @@
 import React, {useState, useEffect} from "react";
 import {connect} from "react-redux";
 import {useHistory, useParams} from "react-router-dom";
-
 import {Alert, Button, Form, Input, Radio, Select} from "antd";
-import "antd/es/alert/style/css";
-import "antd/es/button/style/css";
-import "antd/es/form/style/css";
-import "antd/es/input/style/css";
-import "antd/es/radio/style/css";
-import "antd/es/select/style/css";
 
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";

--- a/src/components/individuals/IndividualsDetailContent.js
+++ b/src/components/individuals/IndividualsDetailContent.js
@@ -2,11 +2,7 @@ import React from "react";
 import {bindActionCreators} from "redux";
 import {connect} from "react-redux";
 import {Link, useHistory, useParams} from "react-router-dom";
-
-import {Descriptions, Space, Spin} from "antd";
-import "antd/es/descriptions/style/css";
-import "antd/es/space/style/css";
-import "antd/es/spin/style/css";
+import {Descriptions} from "antd";
 
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";

--- a/src/components/individuals/IndividualsListContent.js
+++ b/src/components/individuals/IndividualsListContent.js
@@ -1,9 +1,7 @@
 import React from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
-
 import {Button} from "antd";
-import "antd/es/button/style/css";
 
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";

--- a/src/components/samples/SampleEditContent.js
+++ b/src/components/samples/SampleEditContent.js
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import moment from "moment";
 import {connect} from "react-redux";
 import {useHistory, useParams} from "react-router-dom";
-
 import {
   Alert,
   AutoComplete,
@@ -13,18 +12,7 @@ import {
   InputNumber,
   Select,
   Switch,
-  Typography,
 } from "antd";
-import "antd/es/alert/style/css";
-import "antd/es/auto-complete/style/css";
-import "antd/es/button/style/css";
-import "antd/es/date-picker/style/css";
-import "antd/es/form/style/css";
-import "antd/es/input/style/css";
-import "antd/es/input-number/style/css";
-import "antd/es/select/style/css";
-import "antd/es/switch/style/css";
-import "antd/es/typography/style/css";
 const {Option} = Select
 const {TextArea} = Input
 

--- a/src/components/samples/SamplesDetailContent.js
+++ b/src/components/samples/SamplesDetailContent.js
@@ -14,15 +14,6 @@ import {
   Timeline,
   Typography
 } from "antd";
-import "antd/es/card/style/css";
-import "antd/es/col/style/css";
-import "antd/es/descriptions/style/css";
-import "antd/es/empty/style/css";
-import "antd/es/row/style/css";
-import "antd/es/space/style/css";
-import "antd/es/tag/style/css";
-import "antd/es/timeline/style/css";
-import "antd/es/typography/style/css";
 
 import dateToString from "../../utils/dateToString";
 import useTimeline from "../../utils/useTimeline";

--- a/src/components/samples/SamplesFilters.js
+++ b/src/components/samples/SamplesFilters.js
@@ -2,8 +2,6 @@ import React from "react";
 import {connect} from "react-redux";
 import {filter as filterObject} from "rambda";
 import {Collapse} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/collapse/style/css";
 
 import {setFilter} from "../../modules/samples/actions";
 import FilterGroup from "../filters/FilterGroup";

--- a/src/components/samples/SamplesListContent.js
+++ b/src/components/samples/SamplesListContent.js
@@ -1,10 +1,7 @@
 import React, {useRef} from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
-
 import {Button, Tag} from "antd";
-import "antd/es/button/style/css";
-import "antd/es/tag/style/css";
 
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";

--- a/src/components/users/AutocompleteReport.js
+++ b/src/components/users/AutocompleteReport.js
@@ -1,7 +1,5 @@
 import React, {useState} from "react";
-
 import {AutoComplete} from "antd";
-import "antd/es/auto-complete/style/css";
 
 import filterAutocompleteOptions from "../../utils/filterAutocompleteOptions";
 

--- a/src/components/users/UsersDetailContent.js
+++ b/src/components/users/UsersDetailContent.js
@@ -12,7 +12,6 @@ import {
   values,
 } from "rambda";
 import {set} from "object-path-immutable";
-
 import {
   Button,
   Card,
@@ -24,15 +23,6 @@ import {
   Timeline,
   Typography,
 } from "antd";
-import "antd/es/button/style/css";
-import "antd/es/card/style/css";
-import "antd/es/col/style/css";
-import "antd/es/descriptions/style/css";
-import "antd/es/row/style/css";
-import "antd/es/space/style/css";
-import "antd/es/table/style/css";
-import "antd/es/timeline/style/css";
-import "antd/es/typography/style/css";
 import {
   ArrowsAltOutlined,
   ShrinkOutlined,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -2,9 +2,7 @@ import React from "react";
 import {combineReducers} from "redux";
 import {persistReducer} from "redux-persist";
 import storage from "redux-persist/lib/storage";
-
 import {notification} from "antd";
-import "antd/es/notification/style/css";
 
 import {auth} from "./modules/auth/reducers";
 import {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import {Typography} from "antd";
-import "antd/es/typography/style/css";
 const {Text} = Typography
 
 

--- a/src/utils/renderSampleDiff.js
+++ b/src/utils/renderSampleDiff.js
@@ -3,7 +3,6 @@ import {diff} from "jsondiffpatch";
 
 import {SwapRightOutlined} from "@ant-design/icons";
 import {Tag} from "antd";
-import "antd/es/tag/style/css";
 
 const removedStyle = {
   textDecoration: 'line-through',

--- a/src/utils/templateActions.js
+++ b/src/utils/templateActions.js
@@ -2,8 +2,6 @@ import React from "react";
 import {Link} from "react-router-dom";
 
 import {Button} from "antd";
-import "antd/es/button/style/css";
-
 import {EditOutlined, ExperimentOutlined, ExportOutlined, PlusOutlined} from "@ant-design/icons";
 
 export const actionIcon = a => {


### PR DESCRIPTION
When #41 is merged, rebase this one on master and remove all remaining antd style imports.

Styles will be auto-imported at build time instead of manually.