### PR TITLE
Quick fix for remaining BiospecimenTypes

### DIFF
--- a/src/components/JumpBar.js
+++ b/src/components/JumpBar.js
@@ -32,13 +32,15 @@ let lastItems = loadLastItems()
 const mapStateToProps = state => ({
   isFetching: state.query.isFetching,
   items: state.query.items,
+  sampleKindsByID: state.sampleKinds.itemsByID
 });
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators({clear, search}, dispatch);
 
 
-const JumpBar = ({items, isFetching, clear, search}) => {
+const JumpBar = (props) => {
+  const {items, sampleKindsByID, isFetching, clear, search} = props
   const [value, setValue] = useState('');
   const history = useHistory();
 
@@ -75,7 +77,7 @@ const JumpBar = ({items, isFetching, clear, search}) => {
       onChange={onChange}
       onSearch={onSearch}
     >
-      {(value === '' ? lastItems : items).map(renderItem)}
+      {(value === '' ? lastItems : items).map(item => renderItem(item, props))}
     </Select>
   </>;
 };
@@ -90,10 +92,10 @@ function getPath(type, id) {
   throw new Error('unreachable')
 }
 
-function renderItem(r) {
+function renderItem(r, props) {
   switch (r.type) {
     case 'container': return renderContainer(r.item)
-    case 'sample': return renderSample(r.item)
+    case 'sample': return renderSample(r.item, props.sampleKindsByID)
     case 'individual': return renderIndividual(r.item)
     case 'user': return renderUser(r.item)
   }
@@ -113,14 +115,16 @@ function renderContainer(container) {
   );
 }
 
-function renderSample(sample) {
+function renderSample(sample, sampleKindsByID) {
+  const sampleKind = sampleKindsByID?.[sample.sample_kind]?.name
+
   return (
     <Option key={'sample_' + sample.id}>
       <ExperimentOutlined />{' '}
       <strong>{sample.name}</strong>{' '}
-      {sample.biospecimen_type &&
+      {sampleKind &&
         <>
-          <Tag style={tagStyle}>{sample.biospecimen_type}</Tag>{' '}
+          <Tag style={tagStyle}>{sampleKind}</Tag>{' '}
         </>
       }
       <Text type="secondary">sample</Text>{' '}

--- a/src/components/containers/ContainerHierarchy.js
+++ b/src/components/containers/ContainerHierarchy.js
@@ -121,7 +121,7 @@ const buildContainerTreeFromPath = (context, path) => {
           title: <span style={entryStyle}>
             <strong>{sample.name}</strong>{' '}
             <Text type="secondary">
-              sample ({sample.biospecimen_type})
+              sample ({context.sampleKinds.itemsByID[sample.sample_kind]?.name})
             </Text>
           </span>,
           icon: <CheckOutlined />,
@@ -143,11 +143,12 @@ const buildContainerTreeFromPath = (context, path) => {
 const mapStateToProps = state => ({
   containersByID: state.containers.itemsByID,
   samplesByID: state.samples.itemsByID,
+  sampleKinds: state.sampleKinds,
 });
 
 const actionCreators = {get, listChildren, listSamples};
 
-const ContainerHierarchy = ({container, containersByID, samplesByID, listChildren, listSamples}) => {
+const ContainerHierarchy = ({container, containersByID, samplesByID, sampleKinds, listChildren, listSamples}) => {
   if (!container || !container.parents)
     return <LoadingOutlined />;
 
@@ -159,6 +160,7 @@ const ContainerHierarchy = ({container, containersByID, samplesByID, listChildre
   const context = {
     containersByID,
     samplesByID,
+    sampleKinds,
     explodedKeys,
   }
   const path = container.parents.concat([container.id]);

--- a/src/components/samples/SampleEditContent.js
+++ b/src/components/samples/SampleEditContent.js
@@ -56,7 +56,7 @@ const listCollectionSites = (token) => {
 const mapStateToProps = state => ({
   token: state.auth.tokens.access,
   samplesByID: state.samples.itemsByID,
-  sampleKinds: state.sampleKinds.items,
+  sampleKinds: state.sampleKinds,
 });
 
 const actionCreators = {add, update};
@@ -169,7 +169,9 @@ const SampleEditContent = ({token, samplesByID, sampleKinds, add, update}) => {
       help: formErrors[name],
     }
 
-  const isTissueEnabled = tissueEnabled(formData?.biospecimen_type)
+  const sampleKindName = (sampleKindID) => sampleKinds.itemsByID[sampleKindID]?.name
+
+  const isTissueEnabled = tissueEnabled(sampleKindName(formData?.sample_kind))
 
   return (
     <>
@@ -195,7 +197,7 @@ const SampleEditContent = ({token, samplesByID, sampleKinds, add, update}) => {
           </Form.Item>
           <Form.Item label="Sample Kind" {...props("sample_kind")} rules={requiredRules}>
             <Select>
-              {sampleKinds.map(sk =>
+              {sampleKinds.items.map(sk =>
                 <Option key={sk.name} value={sk.id}>{sk.name}</Option>
               )}
             </Select>

--- a/src/components/samples/SamplesDetailContent.js
+++ b/src/components/samples/SamplesDetailContent.js
@@ -59,6 +59,7 @@ const SamplesDetailContent = ({samplesByID, sampleKindsByID, containersByID, ind
   const error = sample.error?.name !== 'APIError' ? sample.error : undefined;
   const isLoaded = samplesByID[id] && !sample.isFetching && !sample.didFail;
   const isFetching = !samplesByID[id] || sample.isFetching;
+  const sampleKind = sampleKindsByID[sample.sample_kind]?.name
   const volume = sample.volume_history
     ? parseFloat(sample.volume_history[sample.volume_history.length - 1].volume_value).toFixed(3)
     : null;
@@ -81,7 +82,7 @@ const SamplesDetailContent = ({samplesByID, sampleKindsByID, containersByID, ind
       extra={isLoaded ?
         <Space>
           <div key="kind" style={{display: "inline-block", verticalAlign: "top", marginTop: "4px"}}>
-              <Tag>{sample.biospecimen_type}</Tag>
+              <Tag>{sampleKind}</Tag>
           </div>
           <div key="depleted" style={depletedStyle}>
               <Tag color={sample.depleted ? "red" : "green"}>{sample.depleted ? "" : "NOT "}DEPLETED</Tag>
@@ -100,7 +101,7 @@ const SamplesDetailContent = ({samplesByID, sampleKindsByID, containersByID, ind
       <Descriptions bordered={true} size="small">
           <Descriptions.Item label="Name">{sample.name}</Descriptions.Item>
           <Descriptions.Item label="Alias">{sample.alias}</Descriptions.Item>
-          <Descriptions.Item label="Sample Kind">{sampleKindsByID[sample.sample_kind]?.name}</Descriptions.Item>
+          <Descriptions.Item label="Sample Kind">{sampleKind}</Descriptions.Item>
           <Descriptions.Item label="Volume">{volume} µL</Descriptions.Item>
           <Descriptions.Item label="Concentration">
               {sample.concentration == null

--- a/src/models.js
+++ b/src/models.js
@@ -33,7 +33,7 @@ export const container = {
 export const sample = {
   name: "",
   alias: "",
-  biospecimen_type: null,
+  sample_kind: null,
   volume_history: null, // 
   concentration: null,
   depleted: false,
@@ -53,7 +53,7 @@ export const sample = {
 // Example:
 // {
 //     id: 9551,
-//     biospecimen_type: "DNA",
+//     sample_kind: 1,
 //     name: "0110",
 //     alias: "",
 //     volume_history: [


### PR DESCRIPTION
There were a few BiospecimenType remaining. While this is working as a quick fix, we might have to think about a pattern to have the SampleKind states mapped to props in more Components, because this will be useful in any page related to Samples, as well as in the Jump Bar (which was not modified yet).

Also, do you have an idea on how to pass that in the Jump Bar component? renderSample (within renderItem) are outside of the JumpBar component, so it is not very clean to pass the SampleKind from there as props, to the renderItem function in the return..
